### PR TITLE
Implement Swarm deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 target/
 work/
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
             <artifactId>kubernetes-client</artifactId>
             <version>${kubernetes-client.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.8.47</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/microsoft/jenkins/acs/ACSDeploymentContext.java
+++ b/src/main/java/com/microsoft/jenkins/acs/ACSDeploymentContext.java
@@ -50,6 +50,7 @@ import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nonnull;
@@ -71,9 +72,11 @@ public class ACSDeploymentContext extends AbstractBaseContext
     private final String resourceGroupName;
     private final String containerService;
     private final String sshCredentialsId;
-    private final String kubernetesNamespace;
     private final String configFilePaths;
-    private final boolean enableConfigSubstitution;
+
+    private boolean enableConfigSubstitution;
+    private String kubernetesNamespace;
+    private boolean swarmRemoveContainersFirst;
 
     private transient Azure azureClient;
     private transient String mgmtFQDN;
@@ -87,16 +90,12 @@ public class ACSDeploymentContext extends AbstractBaseContext
             final String resourceGroupName,
             final String containerService,
             final String sshCredentialsId,
-            final String kubernetesNamespace,
-            final String configFilePaths,
-            final boolean enableConfigSubstitution) {
+            final String configFilePaths) {
         this.azureCredentialsId = azureCredentialsId;
         this.resourceGroupName = resourceGroupName;
         this.containerService = containerService;
         this.sshCredentialsId = sshCredentialsId;
-        this.kubernetesNamespace = kubernetesNamespace;
         this.configFilePaths = configFilePaths;
-        this.enableConfigSubstitution = enableConfigSubstitution;
     }
 
     @Override
@@ -217,9 +216,29 @@ public class ACSDeploymentContext extends AbstractBaseContext
         return kubernetesNamespace;
     }
 
+    @DataBoundSetter
+    public void setKubernetesNamespace(final String kubernetesNamespace) {
+        this.kubernetesNamespace = kubernetesNamespace;
+    }
+
+    @Override
+    public boolean getSwarmRemoveContainersFirst() {
+        return this.swarmRemoveContainersFirst;
+    }
+
+    @DataBoundSetter
+    public void setSwarmRemoveContainersFirst(final boolean swarmRemoveContainersFirst) {
+        this.swarmRemoveContainersFirst = swarmRemoveContainersFirst;
+    }
+
     @Override
     public boolean isEnableConfigSubstitution() {
         return enableConfigSubstitution;
+    }
+
+    @DataBoundSetter
+    public void setEnableConfigSubstitution(final boolean enableConfigSubstitution) {
+        this.enableConfigSubstitution = enableConfigSubstitution;
     }
 
     public void configure(

--- a/src/main/java/com/microsoft/jenkins/acs/commands/DeploymentChoiceCommand.java
+++ b/src/main/java/com/microsoft/jenkins/acs/commands/DeploymentChoiceCommand.java
@@ -39,6 +39,8 @@ public class DeploymentChoiceCommand
                 return KubernetesDeploymentCommand.class;
             case DCOS:
                 return MarathonDeploymentCommand.class;
+            case SWARM:
+                return SwarmDeploymentCommand.class;
             default:
                 throw new IllegalStateException(
                         Messages.DeploymentChoiceCommand_orchestratorNotSupported(orchestratorType));

--- a/src/main/java/com/microsoft/jenkins/acs/commands/EnablePortCommand.java
+++ b/src/main/java/com/microsoft/jenkins/acs/commands/EnablePortCommand.java
@@ -32,7 +32,7 @@ public class EnablePortCommand implements ICommand<EnablePortCommand.IEnablePort
     public static final int SECURITY_RULE_MAX_PRIORITY = 4086;
     public static final int LOAD_BALANCER_IDLE_TIMEOUT_IN_MINUTES = 5;
 
-    private static final class InvalidConfigException extends Exception {
+    static final class InvalidConfigException extends Exception {
         InvalidConfigException(final String message) {
             super(message);
         }
@@ -52,9 +52,9 @@ public class EnablePortCommand implements ICommand<EnablePortCommand.IEnablePort
             final String resourcePrefix = config.getResourcePrefix();
             final List<ServicePort> servicePorts = config.getServicePorts();
 
-            createSecurityRule(context, azureClient, resourceGroupName, resourcePrefix, servicePorts);
+            createSecurityRules(context, azureClient, resourceGroupName, resourcePrefix, servicePorts);
 
-            createLoadBalancerRule(context, azureClient, resourceGroupName, resourcePrefix, servicePorts);
+            createLoadBalancerRules(context, azureClient, resourceGroupName, resourcePrefix, servicePorts);
 
             context.setDeploymentState(DeploymentState.Success);
         } catch (IOException | InvalidConfigException | DeploymentConfig.InvalidFormatException e) {
@@ -122,7 +122,7 @@ public class EnablePortCommand implements ICommand<EnablePortCommand.IEnablePort
         return maxPriority;
     }
 
-    private static void createSecurityRule(
+    static void createSecurityRules(
             final IBaseCommandData context,
             final Azure azureClient,
             final String resourceGroupName,
@@ -186,7 +186,7 @@ public class EnablePortCommand implements ICommand<EnablePortCommand.IEnablePort
         update.apply();
     }
 
-    private static void createLoadBalancerRule(
+    static void createLoadBalancerRules(
             final IBaseCommandData context,
             final Azure azureClient,
             final String resourceGroupName,

--- a/src/main/java/com/microsoft/jenkins/acs/commands/MarathonDeploymentCommand.java
+++ b/src/main/java/com/microsoft/jenkins/acs/commands/MarathonDeploymentCommand.java
@@ -51,7 +51,7 @@ public class MarathonDeploymentCommand implements ICommand<MarathonDeploymentCom
                         jobContext.replaceMacro(configPath.read(), context.isEnableConfigSubstitution()),
                         deployedFilename);
 
-                String appId = JsonHelper.getId(configPath.read());
+                String appId = JsonHelper.getMarathonAppId(configPath.read());
                 //ignore if app does not exist
                 context.logStatus(Messages.MarathonDeploymentCommand_deletingApp(appId));
                 client.execRemote("curl -i -X DELETE http://localhost/marathon/v2/apps/" + appId);

--- a/src/main/java/com/microsoft/jenkins/acs/commands/SwarmDeploymentCommand.java
+++ b/src/main/java/com/microsoft/jenkins/acs/commands/SwarmDeploymentCommand.java
@@ -1,0 +1,76 @@
+package com.microsoft.jenkins.acs.commands;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.jcraft.jsch.JSchException;
+import com.microsoft.jenkins.acs.JobContext;
+import com.microsoft.jenkins.acs.Messages;
+import com.microsoft.jenkins.acs.orchestrators.DeploymentConfig;
+import com.microsoft.jenkins.acs.util.Constants;
+import com.microsoft.jenkins.acs.util.DeployHelper;
+import com.microsoft.jenkins.acs.util.JSchClient;
+import hudson.FilePath;
+
+import java.io.IOException;
+
+public class SwarmDeploymentCommand implements ICommand<SwarmDeploymentCommand.ISwarmDeploymentCommandData> {
+    public void execute(final SwarmDeploymentCommand.ISwarmDeploymentCommandData context) {
+        final String host = context.getMgmtFQDN();
+        final SSHUserPrivateKey sshCredentials = context.getSshCredentials();
+        final String linuxAdminUsername = context.getLinuxAdminUsername();
+        final JobContext jobContext = context.jobContext();
+
+        JSchClient client = null;
+        try {
+            final DeploymentConfig config = context.getDeploymentConfig();
+            if (config == null) {
+                context.logError(Messages.DeploymentConfig_invalidConfig());
+                return;
+            }
+
+            client = new JSchClient(host, Constants.SWARM_SSH_PORT, linuxAdminUsername, sshCredentials, context);
+
+            final FilePath[] configFiles = config.getConfigFiles();
+            for (final FilePath configFile : configFiles) {
+                final String deployedFilename = DeployHelper.generateRandomDeploymentFileName("yml");
+                context.logStatus(Messages.SwarmDeploymentCommand_copyConfigFileTo(
+                        configFile.getRemote(), client.getHost(), deployedFilename));
+
+                client.copyTo(
+                        jobContext.replaceMacro(configFile.read(), context.isEnableConfigSubstitution()),
+                        deployedFilename);
+
+                // Note that we have to specify DOCKER_HOST in the command rather than using `ChannelExec.setEnv`
+                // as the latter one sets environment variable through SSH protocol but the default sshd_config
+                // doesn't allow this
+                context.logStatus(Messages.SwarmDeploymentCommand_updatingDockerContainers());
+                client.execRemote(String.format("DOCKER_HOST=:2375 docker-compose -f %s up -d", deployedFilename));
+
+                context.logStatus(Messages.SwarmDeploymentCommand_removeTempFile(deployedFilename));
+                client.execRemote("rm -f " + deployedFilename);
+            }
+
+            context.setDeploymentState(DeploymentState.Success);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            context.logError(e);
+        } catch (JSchException | IOException e) {
+            context.logError(e);
+        } finally {
+            if (client != null) {
+                client.close();
+            }
+        }
+    }
+
+    public interface ISwarmDeploymentCommandData extends IBaseCommandData {
+        String getMgmtFQDN();
+
+        String getLinuxAdminUsername();
+
+        SSHUserPrivateKey getSshCredentials();
+
+        DeploymentConfig getDeploymentConfig() throws IOException, InterruptedException;
+
+        boolean isEnableConfigSubstitution();
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/acs/commands/SwarmDeploymentCommand.java
+++ b/src/main/java/com/microsoft/jenkins/acs/commands/SwarmDeploymentCommand.java
@@ -39,6 +39,11 @@ public class SwarmDeploymentCommand implements ICommand<SwarmDeploymentCommand.I
                         jobContext.replaceMacro(configFile.read(), context.isEnableConfigSubstitution()),
                         deployedFilename);
 
+                if (context.getSwarmRemoveContainersFirst()) {
+                    context.logStatus(Messages.SwarmDeploymentCommand_removingDockerContainers());
+                    client.execRemote(String.format("DOCKER_HOST=:2375 docker-compose -f %s down", deployedFilename));
+                }
+
                 // Note that we have to specify DOCKER_HOST in the command rather than using `ChannelExec.setEnv`
                 // as the latter one sets environment variable through SSH protocol but the default sshd_config
                 // doesn't allow this
@@ -72,5 +77,7 @@ public class SwarmDeploymentCommand implements ICommand<SwarmDeploymentCommand.I
         DeploymentConfig getDeploymentConfig() throws IOException, InterruptedException;
 
         boolean isEnableConfigSubstitution();
+
+        boolean getSwarmRemoveContainersFirst();
     }
 }

--- a/src/main/java/com/microsoft/jenkins/acs/orchestrators/DeploymentConfig.java
+++ b/src/main/java/com/microsoft/jenkins/acs/orchestrators/DeploymentConfig.java
@@ -1,0 +1,32 @@
+package com.microsoft.jenkins.acs.orchestrators;
+
+import hudson.FilePath;
+
+import java.io.IOException;
+import java.util.List;
+
+public abstract class DeploymentConfig {
+
+    private final FilePath[] configFiles;
+
+    public DeploymentConfig(final FilePath[] configFiles) {
+        this.configFiles = configFiles;
+    }
+
+    public FilePath[] getConfigFiles() {
+        return configFiles;
+    }
+
+    public abstract  String getResourcePrefix();
+
+    public abstract List<ServicePort> getServicePorts()
+            throws IOException, InvalidFormatException, InterruptedException;
+
+    public static final class InvalidFormatException extends Exception {
+
+        public InvalidFormatException(final String msg) {
+            super(msg);
+        }
+
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/acs/orchestrators/DeploymentConfig.java
+++ b/src/main/java/com/microsoft/jenkins/acs/orchestrators/DeploymentConfig.java
@@ -28,5 +28,9 @@ public abstract class DeploymentConfig {
             super(msg);
         }
 
+        public InvalidFormatException(final Exception ex) {
+            super(ex);
+        }
+
     }
 }

--- a/src/main/java/com/microsoft/jenkins/acs/orchestrators/KubernetesDeploymentConfig.java
+++ b/src/main/java/com/microsoft/jenkins/acs/orchestrators/KubernetesDeploymentConfig.java
@@ -1,0 +1,26 @@
+package com.microsoft.jenkins.acs.orchestrators;
+
+import hudson.FilePath;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class KubernetesDeploymentConfig extends DeploymentConfig {
+
+    public KubernetesDeploymentConfig(final FilePath[] configFiles) {
+        super(configFiles);
+    }
+
+    @Override
+    public String getResourcePrefix() {
+        return "k8s";
+    }
+
+    @Override
+    public List<ServicePort> getServicePorts() throws IOException, InvalidFormatException, InterruptedException {
+        // ACS with Kubernetes will add a security rule for the service port automatically,
+        // so here we just return an empty list
+        return Arrays.asList();
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/acs/orchestrators/MarathonDeploymentConfig.java
+++ b/src/main/java/com/microsoft/jenkins/acs/orchestrators/MarathonDeploymentConfig.java
@@ -1,0 +1,45 @@
+package com.microsoft.jenkins.acs.orchestrators;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.management.network.Protocol;
+import hudson.FilePath;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class MarathonDeploymentConfig extends DeploymentConfig {
+
+    public MarathonDeploymentConfig(final FilePath[] configFiles) {
+        super(configFiles);
+    }
+
+    @Override
+    public String getResourcePrefix() {
+        return "dcos";
+    }
+
+    @Override
+    public List<ServicePort> getServicePorts() throws IOException, InterruptedException {
+        ArrayList<ServicePort> servicePorts = new ArrayList<ServicePort>();
+
+        for (final FilePath configFile : getConfigFiles()) {
+            try (InputStream cfgFile = configFile.read()) {
+                final ObjectMapper mapper = new ObjectMapper();
+                JsonNode parentNode = mapper.readTree(cfgFile);
+                JsonNode node = parentNode.get("container").get("docker").get("portMappings");
+                Iterator<JsonNode> elements = node.elements();
+                while (elements.hasNext()) {
+                    JsonNode element = elements.next();
+                    int port = element.get("hostPort").asInt();
+                    servicePorts.add(new ServicePort(port, port, Protocol.TCP));
+                }
+            }
+        }
+
+        return servicePorts;
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/acs/orchestrators/MarathonDeploymentConfig.java
+++ b/src/main/java/com/microsoft/jenkins/acs/orchestrators/MarathonDeploymentConfig.java
@@ -1,8 +1,10 @@
 package com.microsoft.jenkins.acs.orchestrators;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.management.network.Protocol;
+import com.microsoft.jenkins.acs.Messages;
 import hudson.FilePath;
 
 import java.io.IOException;
@@ -23,19 +25,59 @@ public class MarathonDeploymentConfig extends DeploymentConfig {
     }
 
     @Override
-    public List<ServicePort> getServicePorts() throws IOException, InterruptedException {
+    public List<ServicePort> getServicePorts() throws IOException, InterruptedException, InvalidFormatException {
         ArrayList<ServicePort> servicePorts = new ArrayList<ServicePort>();
 
         for (final FilePath configFile : getConfigFiles()) {
             try (InputStream cfgFile = configFile.read()) {
                 final ObjectMapper mapper = new ObjectMapper();
-                JsonNode parentNode = mapper.readTree(cfgFile);
-                JsonNode node = parentNode.get("container").get("docker").get("portMappings");
+
+                JsonNode node = null;
+                try {
+                    node = mapper.readTree(cfgFile);
+                } catch (JsonProcessingException e) {
+                    throw new InvalidFormatException(e);
+                }
+
+                // Walk down the tree to find the `container.docker.portMappings` node
+                final String[] fieldKeys = new String[]{"container", "docker", "portMappings"};
+                for (int i = 0; i < fieldKeys.length; i++) {
+                    final String fieldKey = fieldKeys[i];
+                    node = node.get(fieldKey);
+                    if (node == null) {
+                        throw new InvalidFormatException(
+                                Messages.MarathonDeploymentConfig_invalidConfigFormatNodeNotFound(
+                                        configFile.getRemote(), fieldKey));
+                    }
+                }
+
                 Iterator<JsonNode> elements = node.elements();
                 while (elements.hasNext()) {
                     JsonNode element = elements.next();
-                    int port = element.get("hostPort").asInt();
-                    servicePorts.add(new ServicePort(port, port, Protocol.TCP));
+
+                    JsonNode containerPortNode = element.get("containerPort");
+                    if (containerPortNode == null) {
+                        throw new InvalidFormatException(
+                                Messages.MarathonDeploymentConfig_invalidConfigFormatNodeNotFound(
+                                        configFile.getRemote(), "container.docker.portMapping[].containerPort"));
+                    }
+                    int containerPort = containerPortNode.asInt();
+
+                    JsonNode hostPortNode = element.get("hostPort");
+                    if (hostPortNode == null) {
+                        throw new InvalidFormatException(
+                                Messages.MarathonDeploymentConfig_invalidConfigFormatNodeNotFound(
+                                        configFile.getRemote(), "container.docker.portMapping[].hostPort"));
+                    }
+                    int hostPort = hostPortNode.asInt();
+
+                    Protocol protocol = Protocol.TCP;
+                    JsonNode protocolNode = element.get("protocol");
+                    if (protocolNode != null && protocolNode.asText().equalsIgnoreCase("udp")) {
+                        protocol = Protocol.UDP;
+                    }
+
+                    servicePorts.add(new ServicePort(hostPort, containerPort, protocol));
                 }
             }
         }

--- a/src/main/java/com/microsoft/jenkins/acs/orchestrators/ServicePort.java
+++ b/src/main/java/com/microsoft/jenkins/acs/orchestrators/ServicePort.java
@@ -1,0 +1,68 @@
+package com.microsoft.jenkins.acs.orchestrators;
+
+import com.microsoft.azure.management.network.LoadBalancingRule;
+import com.microsoft.azure.management.network.Protocol;
+import com.microsoft.azure.management.network.TransportProtocol;
+
+public class ServicePort {
+
+    private final int hostPort;
+    private final int containerPort;
+    private final Protocol protocol;
+
+    public ServicePort(final int hostPort, final int containerPort, final Protocol protocol) {
+        this.hostPort = hostPort;
+        this.containerPort = containerPort;
+        this.protocol = protocol;
+    }
+
+    public int getHostPort() {
+        return hostPort;
+    }
+
+    public int getContainerPort() {
+        return containerPort;
+    }
+
+    public Protocol getProtocol() {
+        return protocol;
+    }
+
+    public TransportProtocol getTransportProtocol() {
+        if (protocol.equals(Protocol.TCP)) {
+            return TransportProtocol.TCP;
+        } else if (protocol.equals(Protocol.UDP)) {
+            return TransportProtocol.UDP;
+        } else {
+            return new TransportProtocol(protocol.toString());
+        }
+    }
+
+    public boolean matchesLoadBalancingRule(final LoadBalancingRule rule) {
+        return rule.frontendPort() == hostPort && rule.protocol().equals(getTransportProtocol());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d:%d/%s", hostPort, containerPort, protocol);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (!(obj instanceof ServicePort)) {
+            return false;
+        } else if (obj == this) {
+            return true;
+        } else {
+            ServicePort other = (ServicePort) obj;
+            return this.hostPort == other.hostPort
+                    && this.containerPort == other.containerPort
+                    && this.protocol == other.protocol;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/acs/orchestrators/SwarmDeploymentConfig.java
+++ b/src/main/java/com/microsoft/jenkins/acs/orchestrators/SwarmDeploymentConfig.java
@@ -1,0 +1,185 @@
+package com.microsoft.jenkins.acs.orchestrators;
+
+import com.microsoft.azure.management.network.Protocol;
+import com.microsoft.jenkins.acs.Messages;
+import hudson.FilePath;
+import hudson.Util;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SwarmDeploymentConfig extends DeploymentConfig {
+
+    public SwarmDeploymentConfig(final FilePath[] configFiles) {
+        super(configFiles);
+    }
+
+    @Override
+    public String getResourcePrefix() {
+        return "swarm";
+    }
+
+    @Override
+    public List<ServicePort> getServicePorts() throws IOException, InvalidFormatException, InterruptedException {
+        final ArrayList<ServicePort> servicePorts = new ArrayList<ServicePort>();
+
+        final FilePath[] configFiles = getConfigFiles();
+        for (final FilePath configFile : configFiles) {
+            try (InputStream cfgFile = configFile.read()) {
+                Yaml yaml = new Yaml();
+                Map<String, Object> root = (Map<String, Object>) yaml.load(cfgFile);
+
+                // For files that do not declare a version are considered the legacy version
+                // See https://docs.docker.com/compose/compose-file/compose-versioning/
+                boolean isLegacyVersion = !root.containsKey("version");
+                Map<String, Object> services = null;
+                if (isLegacyVersion) {
+                    // For legacy version all services are declared at the root of the document
+                    services = root;
+                } else {
+                    // For newer versions all services are declared under the `services` key
+                    services = (Map<String, Object>) root.get("services");
+                    if (services == null) {
+                        throw new InvalidFormatException(Messages.SwarmDeploymentConfig_invalidConfigFormatNodeNotFound(
+                                configFile.getRemote(), "services"));
+                    }
+                }
+
+                for (Object service : services.values()) {
+                    Object portsNode = ((Map) service).get("ports");
+                    if (!(portsNode instanceof List)) {
+                        continue;
+                    }
+
+                    List<Object> ports = (List<Object>) portsNode;
+                    for (Object portNode : ports) {
+                        if (portNode instanceof String) {
+                            servicePorts.addAll(parsePortShortSyntax((String) portNode));
+                        } else if (portNode instanceof Map) {
+                            servicePorts.addAll(parsePortLongSyntax((Map) portNode));
+                        } else {
+                            throw new InvalidFormatException(
+                                    Messages.SwarmDeploymentConfig_invalidPortDefinition(
+                                            portNode.toString(), configFile.getRemote()));
+                        }
+                    }
+                }
+            }
+        }
+
+        return servicePorts;
+    }
+
+    /**
+     * Modified from https://github.com/docker/docker-py/blob/master/docker/utils/ports.py#L3
+     */
+    private static final Pattern PATTERN_PORT_SPEC = Pattern.compile(""
+        + "^"                                           // Match full string
+        + "("                                           // External part
+        + "((?<host>[a-fA-F\\d.:]+):)?"                 // Address
+        + "(?<ext>[\\d]*)(-(?<extEnd>[\\d]+))?:"        // External range
+        + ")?"
+        + "(?<int>[\\d]+)(-(?<intEnd>[\\d]+))?"         // Internal range
+        + "(?<proto>/(udp|tcp))?"                       // Protocol
+        + "$"                                           // Match full string
+    );
+
+    /**
+     * Parse ports in short syntax
+     *
+     * @param def Ports definition in short syntax
+     * @return List of ServicePort
+     * @throws InvalidFormatException
+     * @see <a href="https://docs.docker.com/compose/compose-file/#ports">Docker Compose - Ports</a>
+     */
+    private List<ServicePort> parsePortShortSyntax(final String def) throws InvalidFormatException {
+        final Matcher m = PATTERN_PORT_SPEC.matcher(def);
+        if (!m.matches()) {
+            throw new InvalidFormatException(Messages.SwarmDeploymentConfig_invalidPortSyntax(def));
+        }
+
+        final String interText = m.group("int");
+        final String interEndText = m.group("intEnd");
+        final String extText = m.group("ext");
+        final String extEndText = m.group("extEnd");
+        final String protocolText = Util.fixNull(m.group("proto"));
+
+        final int inter = Integer.valueOf(interText);
+
+        int interEnd = inter;
+        if (interEndText != null) {
+            interEnd = Integer.valueOf(interEndText);
+        }
+
+        int ext = inter;
+        if (extText != null) {
+            ext = Integer.valueOf(extText);
+        }
+
+        int extEnd;
+        if (extEndText != null) {
+            extEnd = Integer.valueOf(extEndText);
+        } else {
+            if (interEnd == inter) {
+                // Mapping single port. For example, "80:8080"
+                extEnd = ext;
+            } else {
+                // Mapping multiple ports. For example, "8080-8081"
+                extEnd = interEnd;
+            }
+        }
+
+        Protocol protocol = Protocol.TCP;
+        if (protocolText.equalsIgnoreCase("/udp")) {
+            protocol = Protocol.UDP;
+        }
+
+        if (extEnd - ext != interEnd - inter) {
+            throw new InvalidFormatException(Messages.SwarmDeploymentConfig_portRangesDontMatchInLength(def));
+        }
+
+        final ArrayList<ServicePort> servicePorts = new ArrayList<ServicePort>();
+        for (int p = ext; p <= extEnd; p++) {
+            servicePorts.add(new ServicePort(p, inter + p - ext, protocol));
+        }
+
+        return servicePorts;
+    }
+    /**
+     * Parse ports in long syntax
+     *
+     * @param node Node of port definition
+     * @return List of ServicePort
+     * @throws InvalidFormatException
+     * @see <a href="https://docs.docker.com/compose/compose-file/#ports">Docker Compose - Ports</a>
+     */
+    private List<ServicePort> parsePortLongSyntax(final Map node) throws InvalidFormatException {
+        final Object targetNode = node.get("target");
+        if (targetNode == null || !(targetNode instanceof Integer)) {
+            throw new InvalidFormatException(Messages.SwarmDeploymentConfig_noTargetPort());
+        }
+
+        final Object publishedNode = node.get("published");
+        if (publishedNode == null || !(publishedNode instanceof Integer)) {
+            throw new InvalidFormatException(Messages.SwarmDeploymentConfig_noPublishedPort());
+        }
+
+        final Object protocolNode = node.get("protocol");
+        Protocol protocol = Protocol.TCP;
+        if (protocolNode != null && protocolNode instanceof String) {
+            final String protocolText = (String) protocolNode;
+            if (protocolText.equalsIgnoreCase("udp")) {
+                protocol = Protocol.UDP;
+            }
+        }
+
+        return Arrays.asList(new ServicePort((Integer) publishedNode, (Integer) targetNode, protocol));
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/acs/util/Constants.java
+++ b/src/main/java/com/microsoft/jenkins/acs/util/Constants.java
@@ -37,11 +37,13 @@ public final class Constants {
 
     public static final Set<ContainerServiceOchestratorTypes> SUPPORTED_ORCHESTRATOR = new HashSet<>(Arrays.asList(
             ContainerServiceOchestratorTypes.KUBERNETES,
-            ContainerServiceOchestratorTypes.DCOS
+            ContainerServiceOchestratorTypes.DCOS,
+            ContainerServiceOchestratorTypes.SWARM
     ));
 
     public static final int DCOS_SSH_PORT = 2200;
     public static final int KUBERNETES_SSH_PORT = 22;
+    public static final int SWARM_SSH_PORT = 2200;
 
     public static int sshPort(final ContainerServiceOchestratorTypes type) {
         switch (type) {
@@ -49,6 +51,8 @@ public final class Constants {
                 return DCOS_SSH_PORT;
             case KUBERNETES:
                 return KUBERNETES_SSH_PORT;
+            case SWARM:
+                return SWARM_SSH_PORT;
             default:
                 return -1;
         }

--- a/src/main/java/com/microsoft/jenkins/acs/util/DeployHelper.java
+++ b/src/main/java/com/microsoft/jenkins/acs/util/DeployHelper.java
@@ -1,0 +1,14 @@
+package com.microsoft.jenkins.acs.util;
+
+import java.util.Calendar;
+
+public final class DeployHelper {
+
+    private DeployHelper() {
+        // Hide
+    }
+
+    public static String generateRandomDeploymentFileName(final String suffix) {
+        return "acsDep" + Calendar.getInstance().getTimeInMillis() + "." + suffix;
+    }
+}

--- a/src/main/java/com/microsoft/jenkins/acs/util/JSchClient.java
+++ b/src/main/java/com/microsoft/jenkins/acs/util/JSchClient.java
@@ -182,7 +182,7 @@ public class JSchClient {
                         continue;
                     }
                     log(Messages.JSchClient_commandExitStatus(channel.getExitStatus()));
-                    if (channel.getExitStatus() < 0) {
+                    if (channel.getExitStatus() != 0) {
                         throw new RuntimeException(Messages.JSchClient_errorExecution(channel.getExitStatus()));
                     }
                     break;

--- a/src/main/java/com/microsoft/jenkins/acs/util/JSchClient.java
+++ b/src/main/java/com/microsoft/jenkins/acs/util/JSchClient.java
@@ -163,6 +163,10 @@ public class JSchClient {
             channel.connect();
             InputStream in = channel.getInputStream();
 
+            if (context != null) {
+                channel.setErrStream(context.jobContext().getTaskListener().getLogger(), true);
+            }
+
             while (true) {
                 do {
                     // blocks on IO

--- a/src/main/java/com/microsoft/jenkins/acs/util/JsonHelper.java
+++ b/src/main/java/com/microsoft/jenkins/acs/util/JsonHelper.java
@@ -11,29 +11,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Iterator;
 
 public final class JsonHelper {
-    public static ArrayList<Integer> getHostPorts(final InputStream in) throws IOException {
-        ArrayList<Integer> hostPorts = new ArrayList<>();
-        try {
-            final ObjectMapper mapper = new ObjectMapper();
-            JsonNode parentNode = mapper.readTree(in);
-            JsonNode node = parentNode.get("container").get("docker").get("portMappings");
-            Iterator<JsonNode> elements = node.elements();
-            while (elements.hasNext()) {
-                JsonNode element = elements.next();
-                hostPorts.add(element.get("hostPort").asInt());
-            }
-        } finally {
-            in.close();
-        }
-
-        return hostPorts;
-    }
-
-    public static String getId(final InputStream in) throws IOException {
+    public static String getMarathonAppId(final InputStream in) throws IOException {
         try {
             final ObjectMapper mapper = new ObjectMapper();
             JsonNode parentNode = mapper.readTree(in);

--- a/src/main/resources/com/microsoft/jenkins/acs/ACSDeploymentContext/config.jelly
+++ b/src/main/resources/com/microsoft/jenkins/acs/ACSDeploymentContext/config.jelly
@@ -20,11 +20,6 @@
         <c:select expressionAllowed="false"/>
     </f:entry>
 
-    <f:entry title="${%kubernetesNamespace_title}" field="kubernetesNamespace"
-             help="/plugin/azure-acs/help-kubernetesNamespace.html">
-        <f:textbox default="${descriptor.getDefaultKubernetesNamespace()}" clazz="kubernetes-optional"/>
-    </f:entry>
-
     <f:entry title="${%configFilePaths_title}" field="configFilePaths"
              help="/plugin/azure-acs/help-configFilePaths.html">
         <f:textbox/>
@@ -33,6 +28,16 @@
     <f:entry title="${%enableConfigSubstitution_title}" field="enableConfigSubstitution"
              help="/plugin/azure-acs/help-enableConfigSubstitution.html">
         <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="${%kubernetesNamespace_title}" field="kubernetesNamespace"
+             help="/plugin/azure-acs/help-kubernetesNamespace.html">
+        <f:textbox default="${descriptor.getDefaultKubernetesNamespace()}" clazz="kubernetes-optional"/>
+    </f:entry>
+
+    <f:entry title="${%swarmRemoveContainersFirst_title}" field="swarmRemoveContainersFirst"
+             help="/plugin/azure-acs/help-swarmRemoveContainersFirst.html">
+        <f:checkbox default="false" />
     </f:entry>
 
     <f:validateButton title="${%Verify_Configuration}" progress="${%Verifying}" method="verifyConfiguration"

--- a/src/main/resources/com/microsoft/jenkins/acs/ACSDeploymentContext/config.properties
+++ b/src/main/resources/com/microsoft/jenkins/acs/ACSDeploymentContext/config.properties
@@ -11,5 +11,6 @@ containerService_title = Container Service
 azureCredentialsId_title = Azure Credentials
 sshCredentialsId_title = Master Node SSH Credentials
 kubernetesNamespace_title = Kubernetes Namespace
+swarmRemoveContainersFirst_title = Swarm Remove Containers First
 configFilePaths_title = Config Files
 enableConfigSubstitution_title = Enable Variable Substitution in Config

--- a/src/main/resources/com/microsoft/jenkins/acs/Messages.properties
+++ b/src/main/resources/com/microsoft/jenkins/acs/Messages.properties
@@ -67,6 +67,8 @@ MarathonDeploymentCommand_deletingApp = Deleting application with appId: {0} if 
 MarathonDeploymentCommand_deployingApp = Deploying file '{0}' with appId {1} to marathon.
 MarathonDeploymentCommand_removeTempFile = Remove temporary remote config file: {0}
 
+MarathonDeploymentConfig_invalidConfigFormatNodeNotFound = Invalid config format in {0}: {1} node not found.
+
 SwarmDeploymentCommand_copyConfigFileTo = Copying swarm config file `{0}` to remote: {1}:{2}
 SwarmDeploymentCommand_updatingDockerContainers = Updating docker containers
 SwarmDeploymentCommand_removeTempFile = Remove temporary remote config file: {0}

--- a/src/main/resources/com/microsoft/jenkins/acs/Messages.properties
+++ b/src/main/resources/com/microsoft/jenkins/acs/Messages.properties
@@ -40,15 +40,19 @@ DeploymentChoiceCommand_orchestratorNotSupported = ERROR: Deployment of containe
 EnablePortCommand_enabling = Enabling ports: {0}
 EnablePortCommand_createSecurityRuleIfNeeded = Creating security rule for port {0} if needed.
 EnablePortCommand_securityRuleFound = Security rule for port {0} was found.
-EnablePortCommand_securityGroupNotFound = ERROR: The security group associated to the agents was not found.
+EnablePortCommand_securityRuleNotFound = Security rule for port {0} not found.
+EnablePortCommand_securityGroupNotFound = The security group associated to the agents was not found. Skip checking security rules.
 EnablePortCommand_exceedMaxPriority = ERROR: Exceeded max priority for inbound security rules.
 EnablePortCommand_creatingRule = Creating Security rule for port {0} with name: {1}
 EnablePortCommand_allowTraffic = Allow traffic from the Internet to Public Agents port {0}
 EnablePortCommand_createLBIfNeeded = Creating load balancer rule for port {0} if needed.
 EnablePortCommand_missMatch = ERROR: Balancer configuration from template not matching previous configuration.
-EnablePortCommand_lbFound = Load balancer rule for port {0} found.
-EnablePortCommand_lbNotFound = ERROR: The load balancer associated to the agents was not found.
+EnablePortCommand_lbFound = Load balancer rule for port {0} protocol {1} found.
+EnablePortCommand_lbNotFound = The load balancer associated to the agents was not found. Skip checking load balancing rules.
 EnablePortCommand_creatingLB = Creating load balancer rule for port {0} with name: {1}
+EnablePortCommand_securityRuleAlreadyAllowAll = Security rule {0}({1}) allows all ports already.
+EnablePortCommand_securityRuleInvalidDestinationPortRange = Invalid destination port range format: {0}
+EnablePortCommand_securityRuleAlreadyAllowSingle = Security rule {0}({1}) allows port {2} already.
 
 GetContainserServiceInfoCommand_getFQDN = Getting management public FQDN.
 GetContainserServiceInfoCommand_containerServiceNotFound = Container Service {0} was not found in Resource Group {1}
@@ -57,11 +61,22 @@ GetContainserServiceInfoCommand_orchestratorTypeNotMatch = Container service {0}
 GetContainserServiceInfoCommand_fqdn = Management master FQDN: {0}
 GetContainserServiceInfoCommand_adminUser = Management admin username: {0}
 
-MarathonDeploymentCommand_configNotFoundAt = No configuration found at: {0}
-MarathonDeploymentCommand_copyConfigFileTo = Copying marathon config file '{0}' to remote: {1}:{2}
+MarathonDeploymentCommand_configNotFound = No configuration found.
+MarathonDeploymentCommand_copyConfigFileTo = Copying marathon config file `{0}` to remote: {1}:{2}
 MarathonDeploymentCommand_deletingApp = Deleting application with appId: {0} if it exists
 MarathonDeploymentCommand_deployingApp = Deploying file '{0}' with appId {1} to marathon.
 MarathonDeploymentCommand_removeTempFile = Remove temporary remote config file: {0}
+
+SwarmDeploymentCommand_copyConfigFileTo = Copying swarm config file `{0}` to remote: {1}:{2}
+SwarmDeploymentCommand_updatingDockerContainers = Updating docker containers
+SwarmDeploymentCommand_removeTempFile = Remove temporary remote config file: {0}
+
+SwarmDeploymentConfig_invalidConfigFormatNodeNotFound = Invalid config format in {0}: {1} node not found.
+SwarmDeploymentConfig_invalidPortDefinition = Invalid port definition {0} in {1}
+SwarmDeploymentConfig_invalidPortSyntax = Invalid port syntax: {0}
+SwarmDeploymentConfig_portRangesDontMatchInLength = Port ranges do not match in length: {0}
+SwarmDeploymentConfig_noTargetPort = Not target port specified
+SwarmDeploymentConfig_noPublishedPort = Not published port specified
 
 AzureHelper_servicePrincipalNotFound = No service principal found for credentials ID: {0}
 
@@ -85,3 +100,5 @@ ACSDeploymentRecorder_displayName = Deploy to Azure Container Service
 
 JobContext_failedToGetEnv = Failed to get Job environment variables
 JobContext_nullContent = null content returned
+
+DeploymentConfig_invalidConfig = Invalid deployment config

--- a/src/main/resources/com/microsoft/jenkins/acs/Messages.properties
+++ b/src/main/resources/com/microsoft/jenkins/acs/Messages.properties
@@ -70,6 +70,7 @@ MarathonDeploymentCommand_removeTempFile = Remove temporary remote config file: 
 MarathonDeploymentConfig_invalidConfigFormatNodeNotFound = Invalid config format in {0}: {1} node not found.
 
 SwarmDeploymentCommand_copyConfigFileTo = Copying swarm config file `{0}` to remote: {1}:{2}
+SwarmDeploymentCommand_removingDockerContainers = Removing docker containers
 SwarmDeploymentCommand_updatingDockerContainers = Updating docker containers
 SwarmDeploymentCommand_removeTempFile = Remove temporary remote config file: {0}
 
@@ -88,7 +89,7 @@ JSchClient_copyFileFrom = copy file {0}:{1} to {2}
 JSchClient_sftpError = sftp error
 JSchClient_execCommand = ===> exec: {0}
 JSchClient_commandExitStatus = <== command exit status: {0}
-JSchClient_errorExecution = Error executing SSH command: {0}
+JSchClient_errorExecution = Error executing SSH command, exit code: {0}
 JSchClient_output = <=== {0}
 JSchClient_failedExecution = Failed to execute command
 

--- a/src/main/webapp/help-swarmRemoveContainersFirst.html
+++ b/src/main/webapp/help-swarmRemoveContainersFirst.html
@@ -1,0 +1,3 @@
+<div>
+    Stop and remove containers first.
+</div>

--- a/src/main/webapp/scripts/deployment-context.js
+++ b/src/main/webapp/scripts/deployment-context.js
@@ -1,18 +1,28 @@
 Behaviour.specify("select[name$=containerService]", 'hide-optional-based-on-orchestrator', 10000, function(select) {
-    function handle_change() {
+    function handleChange() {
         var value = $(select).getValue();
-        var c = findNearBy(select, 'kubernetesNamespace');
+
+        var isKubernetes = /\|\s*kubernetes$/i.test(value);
+        var isSwarm = /\|\s*swarm$/i.test(value);
+
+        setElementVisibility('kubernetesNamespace', isKubernetes);
+        setElementVisibility('swarmRemoveContainersFirst', isSwarm);
+    }
+
+    function setElementVisibility(name, show) {
+        var c = findNearBy(select, name);
         if (c === null) {
             return;
         }
-        if (/\|\s*kubernetes$/i.test(value)) {
+
+        if (show) {
             $(c).up('tr').show();
         } else {
             $(c).up('tr').hide();
         }
     }
 
-    handle_change();
-    $(select).on('change', handle_change);
-    $(select).on('click', handle_change);
+    handleChange();
+    $(select).on('change', handleChange);
+    $(select).on('click', handleChange);
 });

--- a/src/test/java/com/microsoft/jenkins/acs/ACSDeploymentContextTest.java
+++ b/src/test/java/com/microsoft/jenkins/acs/ACSDeploymentContextTest.java
@@ -12,7 +12,7 @@ public class ACSDeploymentContextTest {
 
     @Test
     public void commandDataCast() {
-        ACSDeploymentContext context = new ACSDeploymentContext("", "", "", "", "", "", false);
+        ACSDeploymentContext context = new ACSDeploymentContext("", "", "", "", "");
 
         GetContainserServiceInfoCommand.IGetContainserServiceInfoCommandData getInfoData = (GetContainserServiceInfoCommand.IGetContainserServiceInfoCommandData) context;
         DeploymentChoiceCommand.IDeploymentChoiceCommandData choiceData = (DeploymentChoiceCommand.IDeploymentChoiceCommandData) context;

--- a/src/test/java/com/microsoft/jenkins/acs/ACSDeploymentContextTest.java
+++ b/src/test/java/com/microsoft/jenkins/acs/ACSDeploymentContextTest.java
@@ -1,0 +1,24 @@
+package com.microsoft.jenkins.acs;
+
+import com.microsoft.jenkins.acs.commands.DeploymentChoiceCommand;
+import com.microsoft.jenkins.acs.commands.EnablePortCommand;
+import com.microsoft.jenkins.acs.commands.GetContainserServiceInfoCommand;
+import com.microsoft.jenkins.acs.commands.KubernetesDeploymentCommand;
+import com.microsoft.jenkins.acs.commands.MarathonDeploymentCommand;
+import com.microsoft.jenkins.acs.commands.SwarmDeploymentCommand;
+import org.junit.Test;
+
+public class ACSDeploymentContextTest {
+
+    @Test
+    public void commandDataCast() {
+        ACSDeploymentContext context = new ACSDeploymentContext("", "", "", "", "", "", false);
+
+        GetContainserServiceInfoCommand.IGetContainserServiceInfoCommandData getInfoData = (GetContainserServiceInfoCommand.IGetContainserServiceInfoCommandData) context;
+        DeploymentChoiceCommand.IDeploymentChoiceCommandData choiceData = (DeploymentChoiceCommand.IDeploymentChoiceCommandData) context;
+        MarathonDeploymentCommand.IMarathonDeploymentCommandData marathonData = (MarathonDeploymentCommand.IMarathonDeploymentCommandData) context;
+        KubernetesDeploymentCommand.IKubernetesDeploymentCommandData kuberData = (KubernetesDeploymentCommand.IKubernetesDeploymentCommandData) context;
+        SwarmDeploymentCommand.ISwarmDeploymentCommandData swarmData = (SwarmDeploymentCommand.ISwarmDeploymentCommandData) context;
+        EnablePortCommand.IEnablePortCommandData enablePortData = (EnablePortCommand.IEnablePortCommandData) context;
+    }
+}

--- a/src/test/java/com/microsoft/jenkins/acs/commands/EnablePortCommandTest.java
+++ b/src/test/java/com/microsoft/jenkins/acs/commands/EnablePortCommandTest.java
@@ -1,0 +1,724 @@
+package com.microsoft.jenkins.acs.commands;
+
+import com.microsoft.azure.Page;
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.network.LoadBalancer;
+import com.microsoft.azure.management.network.LoadBalancerBackend;
+import com.microsoft.azure.management.network.LoadBalancerFrontend;
+import com.microsoft.azure.management.network.LoadBalancerHttpProbe;
+import com.microsoft.azure.management.network.LoadBalancerInboundNatPool;
+import com.microsoft.azure.management.network.LoadBalancerInboundNatRule;
+import com.microsoft.azure.management.network.LoadBalancerPrivateFrontend;
+import com.microsoft.azure.management.network.LoadBalancerPublicFrontend;
+import com.microsoft.azure.management.network.LoadBalancerTcpProbe;
+import com.microsoft.azure.management.network.LoadBalancers;
+import com.microsoft.azure.management.network.LoadBalancingRule;
+import com.microsoft.azure.management.network.LoadDistribution;
+import com.microsoft.azure.management.network.Network;
+import com.microsoft.azure.management.network.NetworkSecurityGroup;
+import com.microsoft.azure.management.network.NetworkSecurityGroups;
+import com.microsoft.azure.management.network.NetworkSecurityRule;
+import com.microsoft.azure.management.network.Protocol;
+import com.microsoft.azure.management.network.PublicIPAddress;
+import com.microsoft.azure.management.network.TransportProtocol;
+import com.microsoft.azure.management.resources.fluentcore.model.Creatable;
+import com.microsoft.jenkins.acs.orchestrators.ServicePort;
+import com.microsoft.rest.RestException;
+import com.microsoft.rest.ServiceCallback;
+import com.microsoft.rest.ServiceFuture;
+import org.junit.Assert;
+import org.junit.Test;
+import rx.Observable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EnablePortCommandTest {
+
+    private NetworkSecurityRule mockNetworkSecurityRule(final int priority, final String destinationPortRange) {
+        final NetworkSecurityRule rule = mock(NetworkSecurityRule.class);
+        when(rule.destinationPortRange()).thenReturn(destinationPortRange);
+        when(rule.priority()).thenReturn(priority);
+        return rule;
+    }
+
+    @Test
+    public void filterPortsToOpen_RuleAllowAll() throws EnablePortCommand.InvalidConfigException {
+        final IBaseCommandData context = mock(IBaseCommandData.class);
+        final Collection<NetworkSecurityRule> rules = Arrays.asList(
+            mockNetworkSecurityRule(10, "*")
+        );
+        final Set<Integer> portsToOpen = new HashSet<Integer>(Arrays.asList(8080));
+
+        final int maxPriority = EnablePortCommand.filterPortsToOpen(context, rules, portsToOpen);
+        Assert.assertEquals(10, maxPriority);
+        Assert.assertTrue(portsToOpen.isEmpty());
+    }
+
+    @Test
+    public void filterPortsToOpen_RuleRange() throws EnablePortCommand.InvalidConfigException {
+        final IBaseCommandData context = mock(IBaseCommandData.class);
+        final Collection<NetworkSecurityRule> rules = Arrays.asList(
+            mockNetworkSecurityRule(10, "8000-9000")
+        );
+        final Set<Integer> portsToOpen = new HashSet<Integer>(Arrays.asList(8080, 9090));
+
+        final int maxPriority = EnablePortCommand.filterPortsToOpen(context, rules, portsToOpen);
+        Assert.assertEquals(10, maxPriority);
+        Assert.assertEquals(new HashSet<Integer>(Arrays.asList(9090)), portsToOpen);
+    }
+
+    @Test
+    public void filterPortsToOpen_RuleRangeInvalidNumberFormat() throws EnablePortCommand.InvalidConfigException {
+        final IBaseCommandData context = mock(IBaseCommandData.class);
+        final Collection<NetworkSecurityRule> rules = Arrays.asList(
+                mockNetworkSecurityRule(10, "8081-xx")
+        );
+        final Set<Integer> portsToOpen = new HashSet<Integer>(Arrays.asList(8080));
+
+        try {
+            final int maxPriority = EnablePortCommand.filterPortsToOpen(context, rules, portsToOpen);
+            Assert.fail("Should throw InvalidConfigException");
+        } catch (EnablePortCommand.InvalidConfigException e) {
+            // Should throw
+        }
+    }
+
+    @Test
+    public void filterPortsToOpen_RuleSingle() throws EnablePortCommand.InvalidConfigException {
+        final IBaseCommandData context = mock(IBaseCommandData.class);
+        final Collection<NetworkSecurityRule> rules = Arrays.asList(
+                mockNetworkSecurityRule(20, "8080"),
+                mockNetworkSecurityRule(10, "8081")
+        );
+        final Set<Integer> portsToOpen = new HashSet<Integer>(Arrays.asList(8080, 8081, 8082));
+
+        final int maxPriority = EnablePortCommand.filterPortsToOpen(context, rules, portsToOpen);
+        Assert.assertEquals(20, maxPriority);
+        Assert.assertEquals(new HashSet<Integer>(Arrays.asList(8082)), portsToOpen);
+    }
+
+    private NetworkSecurityGroup mockNetworkSecurityGroup(String name, Map<String, NetworkSecurityRule> rulesSet) {
+        final NetworkSecurityGroup nsg = mock(NetworkSecurityGroup.class);
+        when(nsg.name()).thenReturn(name);
+        when(nsg.securityRules()).thenReturn(rulesSet);
+
+        final NetworkSecurityGroup.Update update = mock(NetworkSecurityGroup.Update.class, RETURNS_DEEP_STUBS);
+        when(nsg.update()).thenReturn(update);
+
+        return nsg;
+    }
+
+    private Azure mockAzureClientWithNetworkSecurityGroups(List<NetworkSecurityGroup> nsgList) {
+        final PagedList<NetworkSecurityGroup> nsgs = new PagedList<NetworkSecurityGroup>() {
+            @Override
+            public Page<NetworkSecurityGroup> nextPage(String s) throws RestException, IOException {
+                return null;
+            }
+        };
+        nsgs.addAll(nsgList);
+
+        final NetworkSecurityGroups nsgsMgr = mock(NetworkSecurityGroups.class);
+        when(nsgsMgr.listByResourceGroup(anyString())).thenReturn(nsgs);
+
+        final Azure azureClient = mock(Azure.class);
+        when(azureClient.networkSecurityGroups()).thenReturn(nsgsMgr);
+
+        return azureClient;
+    }
+
+    @Test
+    public void createSecurityRules() throws IOException, EnablePortCommand.InvalidConfigException {
+        final IBaseCommandData context = mock(IBaseCommandData.class);
+
+        final Map<String, NetworkSecurityRule> rulesSet = new HashMap<String, NetworkSecurityRule>();
+        rulesSet.put("rule1", mockNetworkSecurityRule(10, "8080") );
+        rulesSet.put("rule2", mockNetworkSecurityRule(20, "8081") );
+
+        final NetworkSecurityGroup nsg = mockNetworkSecurityGroup("dcos-agent-public-nsg-xxx", rulesSet);
+        final Azure azureClient = mockAzureClientWithNetworkSecurityGroups(Arrays.asList(nsg));
+
+        final List<ServicePort> servicePorts = Arrays.asList(
+            new ServicePort(8080, 8080, Protocol.TCP),
+            new ServicePort(8081, 8081, Protocol.TCP),
+            new ServicePort(8082, 8082, Protocol.TCP),
+            new ServicePort(8083, 8083, Protocol.TCP)
+        );
+
+        EnablePortCommand.createSecurityRules(
+            context,
+            azureClient,
+            "resource-group",
+            "dcos",
+            servicePorts
+        );
+
+        final NetworkSecurityGroup.Update update = nsg.update();
+
+        verify(update
+            .defineRule("Allow_" + 8082)
+            .allowInbound()
+            .fromAnyAddress()
+            .fromAnyPort()
+            .toAnyAddress()
+            .toPort(8082)
+            .withAnyProtocol()
+            .withDescription(anyString())
+            .withPriority(30)
+        ).attach();
+
+        verify(update
+                .defineRule("Allow_" + 8083)
+                .allowInbound()
+                .fromAnyAddress()
+                .fromAnyPort()
+                .toAnyAddress()
+                .toPort(8083)
+                .withAnyProtocol()
+                .withDescription(anyString())
+                .withPriority(40)
+        ).attach();
+    }
+
+    private LoadBalancingRule mockLoadBalancingRule(String name, int frontendPort, TransportProtocol protocol) {
+        final LoadBalancingRule rule = mock(LoadBalancingRule.class);
+
+        when(rule.name()).thenReturn(name);
+        when(rule.frontendPort()).thenReturn(frontendPort);
+        when(rule.protocol()).thenReturn(protocol);
+
+        return rule;
+    }
+
+    private LoadBalancer mockLoadBalancer(String name,
+            Map<String, LoadBalancerBackend> backends,
+            Map<String, LoadBalancerFrontend> frontends,
+            Map<String, LoadBalancingRule> rulesSet) {
+        final LoadBalancer lb = mock(LoadBalancer.class);
+        when(lb.name()).thenReturn(name);
+        when(lb.backends()).thenReturn(backends);
+        when(lb.frontends()).thenReturn(frontends);
+        when(lb.loadBalancingRules()).thenReturn(rulesSet);
+
+        return lb;
+    }
+
+    private Azure mockAzureClientWithLoadBalancers(List<LoadBalancer> lbList) {
+        final PagedList<LoadBalancer> lbs = new PagedList<LoadBalancer>() {
+            @Override
+            public Page<LoadBalancer> nextPage(String s) throws RestException, IOException {
+                return null;
+            }
+        };
+        lbs.addAll(lbList);
+
+        final LoadBalancers lbsMgr = mock(LoadBalancers.class);
+        when(lbsMgr.listByResourceGroup(anyString())).thenReturn(lbs);
+
+        final Azure azureClient = mock(Azure.class);
+        when(azureClient.loadBalancers()).thenReturn(lbsMgr);
+
+        return azureClient;
+    }
+
+    @Test
+    public void createLoadBalancerRules() throws IOException, EnablePortCommand.InvalidConfigException {
+        final IBaseCommandData context = mock(IBaseCommandData.class);
+
+        final Map<String, LoadBalancerBackend> backends = new HashMap<String, LoadBalancerBackend>();
+        final LoadBalancerBackend backend = mock(LoadBalancerBackend.class);
+        when(backend.name()).thenReturn("backend");
+        backends.put("backend", backend);
+
+        final Map<String, LoadBalancerFrontend> frontends = new HashMap<String, LoadBalancerFrontend>();
+        final LoadBalancerFrontend frontend = mock(LoadBalancerFrontend.class);
+        when(frontend.name()).thenReturn("frontend");
+        frontends.put("frontend", frontend);
+
+        final Map<String, LoadBalancingRule> rulesSet = new HashMap<String, LoadBalancingRule>();
+        rulesSet.put("rule1", mockLoadBalancingRule("rule1", 8080, TransportProtocol.TCP));
+        rulesSet.put("rule2", mockLoadBalancingRule("rule2", 8081, TransportProtocol.UDP));
+
+        final LoadBalancer lb = mockLoadBalancer("dcos-agent-lb-xxx", backends, frontends, rulesSet);
+
+        // Mockito has some issues for this kind of builder pattern so we mock manually
+        final MockLoadBalancerUpdate update = new MockLoadBalancerUpdate();
+        when(lb.update()).thenReturn(update);
+
+        final Azure azureClient = mockAzureClientWithLoadBalancers(Arrays.asList(lb));
+
+        final List<ServicePort> servicePorts = Arrays.asList(
+                new ServicePort(8080, 8080, Protocol.TCP),
+                new ServicePort(8081, 8081, Protocol.TCP),
+                new ServicePort(8082, 8082, Protocol.TCP)
+        );
+
+        EnablePortCommand.createLoadBalancerRules(
+                context,
+                azureClient,
+                "resource-group",
+                "dcos",
+                servicePorts
+        );
+
+        Assert.assertTrue(update.isApplied);
+        Assert.assertEquals(2, update.tcpProbes.size());
+
+        Assert.assertEquals("tcpPort8081Probe", update.tcpProbes.get(0).name);
+        Assert.assertEquals(8081, update.tcpProbes.get(0).port);
+        Assert.assertEquals("tcpPort8082Probe", update.tcpProbes.get(1).name);
+        Assert.assertEquals(8082, update.tcpProbes.get(1).port);
+
+        Assert.assertEquals(2, update.rules.size());
+
+        Assert.assertEquals("JLBRuleTCP8081", update.rules.get(0).name);
+        Assert.assertEquals(TransportProtocol.TCP, update.rules.get(0).protocol);
+        Assert.assertEquals("frontend", update.rules.get(0).frontend);
+        Assert.assertEquals(8081, update.rules.get(0).frontendPort);
+        Assert.assertEquals("backend", update.rules.get(0).backend);
+        Assert.assertEquals(8081, update.rules.get(0).backendPort);
+        Assert.assertEquals(EnablePortCommand.LOAD_BALANCER_IDLE_TIMEOUT_IN_MINUTES,
+                update.rules.get(0).idleTimeoutInMinutes);
+        Assert.assertEquals(LoadDistribution.DEFAULT, update.rules.get(0).loadDistribution);
+
+        Assert.assertEquals("JLBRuleTCP8082", update.rules.get(1).name);
+        Assert.assertEquals(TransportProtocol.TCP, update.rules.get(1).protocol);
+        Assert.assertEquals("frontend", update.rules.get(1).frontend);
+        Assert.assertEquals(8082, update.rules.get(1).frontendPort);
+        Assert.assertEquals("backend", update.rules.get(1).backend);
+        Assert.assertEquals(8082, update.rules.get(1).backendPort);
+        Assert.assertEquals(EnablePortCommand.LOAD_BALANCER_IDLE_TIMEOUT_IN_MINUTES,
+                update.rules.get(1).idleTimeoutInMinutes);
+        Assert.assertEquals(LoadDistribution.DEFAULT, update.rules.get(1).loadDistribution);
+    }
+
+    @Test
+    public void createLoadBalancerRules_MissMatchBackendFrontend() throws IOException {
+        final IBaseCommandData context = mock(IBaseCommandData.class);
+
+        final Map<String, LoadBalancerBackend> backends = new HashMap<String, LoadBalancerBackend>();
+        final Map<String, LoadBalancerFrontend> frontends = new HashMap<String, LoadBalancerFrontend>();
+        final Map<String, LoadBalancingRule> rulesSet = new HashMap<String, LoadBalancingRule>();
+        final LoadBalancer lb = mockLoadBalancer("dcos-agent-lb-xxx", backends, frontends, rulesSet);
+
+        // Mockito has some issues for this kind of builder pattern so we mock manually
+        final MockLoadBalancerUpdate update = new MockLoadBalancerUpdate();
+        when(lb.update()).thenReturn(update);
+
+        final Azure azureClient = mockAzureClientWithLoadBalancers(Arrays.asList(lb));
+
+        final List<ServicePort> servicePorts = Arrays.asList(
+                new ServicePort(8080, 8080, Protocol.TCP),
+                new ServicePort(8081, 8081, Protocol.TCP),
+                new ServicePort(8082, 8082, Protocol.TCP)
+        );
+
+        try {
+            EnablePortCommand.createLoadBalancerRules(
+                    context,
+                    azureClient,
+                    "resource-group",
+                    "dcos",
+                    servicePorts
+            );
+            Assert.fail("Should throw InvalidConfigException");
+        } catch (EnablePortCommand.InvalidConfigException ex) {
+            Assert.assertFalse(update.isApplied);
+            Assert.assertTrue(update.tcpProbes.isEmpty());
+            Assert.assertTrue(update.rules.isEmpty());
+        }
+    }
+
+    private static final class MockLoadBalancerTcpProbe implements
+            LoadBalancerTcpProbe.UpdateDefinitionStages.Blank<LoadBalancer.Update>,
+            LoadBalancerTcpProbe.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> {
+
+        private final MockLoadBalancerUpdate update;
+        public final String name;
+        public int port;
+
+        MockLoadBalancerTcpProbe(MockLoadBalancerUpdate update, String name) {
+            this.update = update;
+            this.name = name;
+        }
+
+        @Override
+        public LoadBalancerTcpProbe.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withPort(int port) {
+            this.port = port;
+            return this;
+        }
+
+        @Override
+        public LoadBalancerTcpProbe.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withIntervalInSeconds(int seconds) {
+            Assert.fail("Should not reach");
+            return this;
+        }
+
+        @Override
+        public LoadBalancerTcpProbe.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withNumberOfProbes(int probes) {
+            Assert.fail("Should not reach");
+            return this;
+        }
+
+        @Override
+        public LoadBalancer.Update attach() {
+            this.update.tcpProbes.add(this);
+            return this.update;
+        }
+    }
+
+    private static final class MockLoadBalancingRule implements
+            LoadBalancingRule.UpdateDefinitionStages.Blank<LoadBalancer.Update> ,
+            LoadBalancingRule.UpdateDefinitionStages.WithFrontend<LoadBalancer.Update>,
+            LoadBalancingRule.UpdateDefinitionStages.WithFrontendPort<LoadBalancer.Update>,
+            LoadBalancingRule.UpdateDefinitionStages.WithProbe<LoadBalancer.Update>,
+            LoadBalancingRule.UpdateDefinitionStages.WithBackend<LoadBalancer.Update>,
+            LoadBalancingRule.UpdateDefinitionStages.WithBackendPort<LoadBalancer.Update>,
+            LoadBalancingRule.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> {
+
+        private final MockLoadBalancerUpdate update;
+        public final String name;
+        public int idleTimeoutInMinutes;
+        public LoadDistribution loadDistribution;
+        public String backend;
+        public int backendPort;
+        public String frontend;
+        public int frontendPort;
+        public String probe;
+        public TransportProtocol protocol;
+
+        MockLoadBalancingRule(MockLoadBalancerUpdate update, String name) {
+            this.update = update;
+            this.name = name;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithFrontend<LoadBalancer.Update> withProtocol(TransportProtocol protocol) {
+            this.protocol = protocol;
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithFrontendPort<LoadBalancer.Update> withFrontend(String frontendName) {
+            this.frontend = frontendName;
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithProbe<LoadBalancer.Update> withFrontendPort(int port) {
+            this.frontendPort = port;
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithBackend<LoadBalancer.Update> withProbe(String name) {
+            this.probe = name;
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithBackendPort<LoadBalancer.Update> withBackend(String backendName) {
+            this.backend = backendName;
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withBackendPort(int port) {
+            this.backendPort = port;
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withIdleTimeoutInMinutes(int minutes) {
+            this.idleTimeoutInMinutes = minutes;
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withLoadDistribution(LoadDistribution loadDistribution) {
+            this.loadDistribution = loadDistribution;
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withFloatingIPEnabled() {
+            Assert.fail("Should not reach");
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withFloatingIPDisabled() {
+            Assert.fail("Should not reach");
+            return this;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.WithAttach<LoadBalancer.Update> withFloatingIP(boolean enabled) {
+            Assert.fail("Should not reach");
+            return this;
+        }
+
+        @Override
+        public LoadBalancer.Update attach() {
+            this.update.rules.add(this);
+            return this.update;
+        }
+    }
+
+    private static final class MockLoadBalancerUpdate implements LoadBalancer.Update {
+
+        public boolean isApplied;
+        public final List<MockLoadBalancerTcpProbe> tcpProbes = new ArrayList<MockLoadBalancerTcpProbe>();
+        public final List<MockLoadBalancingRule> rules = new ArrayList<MockLoadBalancingRule>();
+
+        @Override
+        public LoadBalancer.Update withoutBackend(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerBackend.UpdateDefinitionStages.Blank<LoadBalancer.Update> defineBackend(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerBackend.Update updateBackend(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withoutInboundNatPool(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerInboundNatPool.UpdateDefinitionStages.Blank<LoadBalancer.Update> defineInboundNatPool(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerInboundNatPool.Update updateInboundNatPool(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withoutInboundNatRule(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerInboundNatRule.UpdateDefinitionStages.Blank<LoadBalancer.Update> defineInboundNatRule(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerInboundNatRule.Update updateInboundNatRule(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerPrivateFrontend.UpdateDefinitionStages.Blank<LoadBalancer.Update> definePrivateFrontend(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerPrivateFrontend.Update updateInternalFrontend(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerPublicFrontend.UpdateDefinitionStages.Blank<LoadBalancer.Update> definePublicFrontend(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withoutFrontend(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerPublicFrontend.Update updateInternetFrontend(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withLoadBalancingRule(int frontendPort, TransportProtocol protocol, int backendPort) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withLoadBalancingRule(int port, TransportProtocol protocol) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancingRule.UpdateDefinitionStages.Blank<LoadBalancer.Update> defineLoadBalancingRule(String name) {
+            return new MockLoadBalancingRule(this, name);
+        }
+
+        @Override
+        public LoadBalancer.Update withoutLoadBalancingRule(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancingRule.Update updateLoadBalancingRule(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withFrontendSubnet(Network network, String subnetName) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withTcpProbe(int port) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withHttpProbe(String requestPath) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerHttpProbe.UpdateDefinitionStages.Blank<LoadBalancer.Update> defineHttpProbe(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerTcpProbe.UpdateDefinitionStages.Blank<LoadBalancer.Update> defineTcpProbe(String name) {
+            return new MockLoadBalancerTcpProbe(this, name);
+        }
+
+        @Override
+        public LoadBalancer.Update withoutProbe(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerTcpProbe.Update updateTcpProbe(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancerHttpProbe.Update updateHttpProbe(String name) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withExistingPublicIPAddress(PublicIPAddress publicIPAddress) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withExistingPublicIPAddress(String resourceId) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withNewPublicIPAddress(String leafDnsLabel) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withNewPublicIPAddress(Creatable<PublicIPAddress> creatable) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withNewPublicIPAddress() {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withTags(Map<String, String> tags) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withTag(String key, String value) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer.Update withoutTag(String key) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public LoadBalancer apply() {
+            if (this.isApplied) {
+                Assert.fail("Should apply only once");
+            } else {
+                this.isApplied = true;
+            }
+            return null;
+        }
+
+        @Override
+        public Observable<LoadBalancer> applyAsync() {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public ServiceFuture<LoadBalancer> applyAsync(ServiceCallback<LoadBalancer> callback) {
+            Assert.fail("Should not reach");
+            return null;
+        }
+
+        @Override
+        public String key() {
+            Assert.fail("Should not reach");
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/microsoft/jenkins/acs/orchestrators/MarathonDeploymentConfigTest.java
+++ b/src/test/java/com/microsoft/jenkins/acs/orchestrators/MarathonDeploymentConfigTest.java
@@ -1,0 +1,83 @@
+package com.microsoft.jenkins.acs.orchestrators;
+
+import com.microsoft.azure.management.network.Protocol;
+import hudson.FilePath;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class MarathonDeploymentConfigTest {
+    private void assertInvalidFormatException(String content) throws IOException, InterruptedException {
+        final File file = File.createTempFile("tst-acs-", ".yml");
+        file.deleteOnExit();
+        FileUtils.write(file, content, "UTF-8");
+
+        MarathonDeploymentConfig config = new MarathonDeploymentConfig(new FilePath[]{new FilePath(file)});
+        try {
+            List<ServicePort> servicePorts = config.getServicePorts();
+            Assert.fail("Should throw InvalidFormatException but not");
+        } catch (DeploymentConfig.InvalidFormatException e) {
+            // Expected
+        }
+    }
+
+
+    @Test
+    public void getServicePortsInvalidFormat() throws IOException, InterruptedException {
+        String content = "";
+        assertInvalidFormatException(content);
+
+        content = "{}";
+        assertInvalidFormatException(content);
+
+        content = "{\"container\": {}}";
+        assertInvalidFormatException(content);
+
+        content = "{\"container\": {\"docker\":{}}}";
+        assertInvalidFormatException(content);
+
+        content = "{\"container\": {\"docker\":{\"portMappings\": [{\"containerPort\": 80}]}}}";
+        assertInvalidFormatException(content);
+
+        content = "{\"container\": {\"docker\":{\"portMappings\": [{\"hostPort\": 80}]}}}";
+        assertInvalidFormatException(content);
+    }
+
+    private void assertServicePorts(String[] contents, List<ServicePort> expServicePorts)
+            throws IOException, InterruptedException, DeploymentConfig.InvalidFormatException {
+        FilePath[] filePaths = new FilePath[contents.length];
+        for (int i = 0; i < contents.length; i++) {
+            final File file = File.createTempFile("tst-acs-", ".yml");
+            file.deleteOnExit();
+            FileUtils.write(file, contents[i], "UTF-8");
+            filePaths[i] = new FilePath(file);
+        }
+
+        MarathonDeploymentConfig config = new MarathonDeploymentConfig(filePaths);
+        List<ServicePort> servicePorts = config.getServicePorts();
+
+        Assert.assertEquals(expServicePorts.size(), servicePorts.size());
+        for (int i = 0; i < servicePorts.size(); i++) {
+            Assert.assertEquals(expServicePorts.get(i), servicePorts.get(i));
+        }
+    }
+
+    @Test
+    public void getServicePorts() throws InterruptedException, DeploymentConfig.InvalidFormatException, IOException {
+        String[] contents = new String[]{
+                "{\"container\": {\"docker\":{\"portMappings\": [{\"hostPort\": 8080, \"containerPort\": 80}, {\"hostPort\": 8081, \"containerPort\": 8081, \"protocol\": \"udp\"}]}}}",
+                "{\"container\": {\"docker\":{\"portMappings\": [{\"hostPort\": 9090, \"containerPort\": 9090}]}}}",
+        };
+        final List<ServicePort> expServicePorts = Arrays.asList(
+                new ServicePort(8080, 80, Protocol.TCP),
+                new ServicePort(8081, 8081, Protocol.UDP),
+                new ServicePort(9090, 9090, Protocol.TCP)
+        );
+        assertServicePorts(contents, expServicePorts);
+    }
+}

--- a/src/test/java/com/microsoft/jenkins/acs/orchestrators/SwarmDeploymentConfigTest.java
+++ b/src/test/java/com/microsoft/jenkins/acs/orchestrators/SwarmDeploymentConfigTest.java
@@ -14,13 +14,13 @@ import java.util.List;
 
 public class SwarmDeploymentConfigTest {
 
-    private void assertServicePorts(String config, List<ServicePort> expServicePorts) throws IOException, DeploymentConfig.InvalidFormatException, InterruptedException {
+    private void assertServicePorts(String content, List<ServicePort> expServicePorts) throws IOException, DeploymentConfig.InvalidFormatException, InterruptedException {
         final File file = File.createTempFile("tst-acs-", ".yml");
         file.deleteOnExit();
-        FileUtils.write(file, config, "UTF-8");
+        FileUtils.write(file, content, "UTF-8");
 
-        SwarmDeploymentConfig configFile = new SwarmDeploymentConfig(new FilePath[]{new FilePath(file)});
-        List<ServicePort> servicePorts = configFile.getServicePorts();
+        SwarmDeploymentConfig config = new SwarmDeploymentConfig(new FilePath[]{new FilePath(file)});
+        List<ServicePort> servicePorts = config.getServicePorts();
 
         Assert.assertEquals(expServicePorts.size(), servicePorts.size());
         for (int i = 0; i < servicePorts.size(); i++) {

--- a/src/test/java/com/microsoft/jenkins/acs/orchestrators/SwarmDeploymentConfigTest.java
+++ b/src/test/java/com/microsoft/jenkins/acs/orchestrators/SwarmDeploymentConfigTest.java
@@ -1,0 +1,114 @@
+package com.microsoft.jenkins.acs.orchestrators;
+
+
+import com.microsoft.azure.management.network.Protocol;
+import hudson.FilePath;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class SwarmDeploymentConfigTest {
+
+    private void assertServicePorts(String config, List<ServicePort> expServicePorts) throws IOException, DeploymentConfig.InvalidFormatException, InterruptedException {
+        final File file = File.createTempFile("tst-acs-", ".yml");
+        file.deleteOnExit();
+        FileUtils.write(file, config, "UTF-8");
+
+        SwarmDeploymentConfig configFile = new SwarmDeploymentConfig(new FilePath[]{new FilePath(file)});
+        List<ServicePort> servicePorts = configFile.getServicePorts();
+
+        Assert.assertEquals(expServicePorts.size(), servicePorts.size());
+        for (int i = 0; i < servicePorts.size(); i++) {
+            Assert.assertEquals(expServicePorts.get(i), servicePorts.get(i));
+        }
+    }
+
+    @Test
+    public void getServicePortsShortSyntax() throws IOException, DeploymentConfig.InvalidFormatException, InterruptedException {
+        final String config = ""
+            + "nginx:\n"
+            + "  image: nginx\n"
+            + "  ports:\n"
+            + "    - \"9090:80\"\n"
+            + "tomcat:\n"
+            + "  image: tomcat\n"
+            + "  ports:\n"
+            + "    - \"8080\"\n"
+            + "    - \"8081-8082\"\n"
+            + "    - \"8083:8083\"\n"
+            + "    - \"8084-8085:18084-18085\"\n"
+            + "    - \"127.0.0.1:8086:8086\"\n"
+            + "    - \"127.0.0.1:8087-8088:18087-18088\"\n"
+            + "    - \"8089-8090/udp\"\n";
+        final List<ServicePort> expServicePorts = Arrays.asList(
+            new ServicePort(9090, 80, Protocol.TCP),
+            new ServicePort(8080, 8080, Protocol.TCP),
+            new ServicePort(8081, 8081, Protocol.TCP),
+            new ServicePort(8082, 8082, Protocol.TCP),
+            new ServicePort(8083, 8083, Protocol.TCP),
+            new ServicePort(8084, 18084, Protocol.TCP),
+            new ServicePort(8085, 18085, Protocol.TCP),
+            new ServicePort(8086, 8086, Protocol.TCP),
+            new ServicePort(8087, 18087, Protocol.TCP),
+            new ServicePort(8088, 18088, Protocol.TCP),
+            new ServicePort(8089, 8089, Protocol.UDP),
+            new ServicePort(8090, 8090, Protocol.UDP)
+        );
+        assertServicePorts(config, expServicePorts);
+    }
+
+    @Test
+    public void getServicePortsLongSyntax() throws IOException, DeploymentConfig.InvalidFormatException, InterruptedException {
+        final String config = ""
+                + "nginx:\n"
+                + "  image: nginx\n"
+                + "  ports:\n"
+                + "    - \"9090:80\"\n"
+                + "tomcat:\n"
+                + "  image: tomcat\n"
+                + "  ports:\n"
+                + "    - target: 8080\n"
+                + "      published: 8080\n"
+                + "      protocol: tcp\n"
+                + "      mode: host\n"
+                + "    - target: 8081\n"
+                + "      published: 18081\n"
+                + "      protocol: udp\n"
+                + "      mode: host\n";
+        final List<ServicePort> expServicePorts = Arrays.asList(
+                new ServicePort(9090, 80, Protocol.TCP),
+                new ServicePort(8080, 8080, Protocol.TCP),
+                new ServicePort(18081, 8081, Protocol.UDP)
+        );
+        assertServicePorts(config, expServicePorts);
+    }
+
+    @Test
+    public void getServicePortsNonLegacyVersion() throws IOException, DeploymentConfig.InvalidFormatException, InterruptedException {
+        final String config = ""
+                + "version: '2'\n"
+                + "services:\n"
+                + "  nginx:\n"
+                + "    image: nginx\n"
+                + "    ports:\n"
+                + "      - \"9090:80\"\n"
+                + "  tomcat:\n"
+                + "    image: tomcat\n"
+                + "    ports:\n"
+                + "      - target: 8080\n"
+                + "        published: 8080\n"
+                + "        protocol: tcp\n"
+                + "        mode: host\n";
+        final List<ServicePort> expServicePorts = Arrays.asList(
+                new ServicePort(9090, 80, Protocol.TCP),
+                new ServicePort(8080, 8080, Protocol.TCP)
+        );
+        assertServicePorts(config, expServicePorts);
+    }
+
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR includes following major changes:

* Implement Swarm deployment. Basically it's similar to DC/OS and we just copy a config file through SSH and executes a curl command.
* Make some refactoring to `EnablePortCommand`. In some scenarios we need to open multiple ports at the same time so I changed `createSecurityRules` and `createLoadBalanceRules` to update multiple rules through single request to reduce roundtrips. Besides I enhanced the robustness of the logic for existing rule checking.
* Logic for parsing ports from config files are moved into separated classes.